### PR TITLE
Arreglados errores tipográficos.

### DIFF
--- a/doc/source/colisiones.rst
+++ b/doc/source/colisiones.rst
@@ -13,7 +13,7 @@ unos pocos pasos.
 
 - Tienes que pensar "qué" quieres hacer cuando se produce una colisión.
 - Escribir una función de respuesta a la colisión.
-- y por último decirle a pilas que actores son colisionables entre sí.
+- y, por último, decirle a pilas qué actores son colisionables entre sí.
 
 
 Ten en cuenta que cada actor tiene un atributo llamado
@@ -54,7 +54,7 @@ del actor:
 
 .. image:: images/radios.png
 
-Ahora, para poder mover al mono podemos enseñarle
+Ahora, para poder mover al mono, podemos enseñarle
 una habilidad:
 
 .. code-block:: python
@@ -81,8 +81,8 @@ la colisión:
     bananas = [banana]
     pilas.escena_actual().colisiones.agregar(mono, bananas, el_mono_come)
 
-Perfecto, ahora si mueves al mono por la pantalla con el
-mouse podrá comer bananas.
+Perfecto. Ahora, si mueves al mono por la pantalla con el
+mouse, podrá comer bananas.
 
 Intenta crear mas actores que representen bananas y
 agregarlos a la lista que usamos antes, por ejemplo:

--- a/doc/source/como_funciona_pilas_por_dentro.rst
+++ b/doc/source/como_funciona_pilas_por_dentro.rst
@@ -361,7 +361,7 @@ hace ``click`` en la pantalla:
 
     pilas.eventos.click_de_mouse.conectar(crear_bomba)
 
-Si queremos que el mouse deje de crear bombas podemos
+Si queremos que el mouse deje de crear bombas, podemos
 ejecutar la función ``desconectar``:
 
 .. code-block:: python
@@ -420,11 +420,11 @@ argumentos o detalles:
     [ etc...]
 
 Los argumentos indican información adicional del evento, en
-el caso del click observarás que los argumentos con el botón pulsado
+el caso del click, observarás que los argumentos son el botón pulsado
 y la coordenada del puntero.
 
-Cuanto se quiere notificar a las funciones conectadas a
-un eventos simplemente se tiene que invocar al método ``emitir``
+Cuando se quiere notificar a las funciones conectadas a
+un evento simplemente se tiene que invocar al método ``emitir``
 del evento y proveer los argumentos que necesita:
 
 .. code-block:: python
@@ -517,7 +517,7 @@ archivo ``mundo.py```:
 
 
 Aquí puedes ver dos llamadas a métodos del actor, el método
-``actualizar`` se creó para que cada programar escriba
+``actualizar`` se creó para que cada programador escriba
 ahí lo que quiera que el personaje haga (leer el teclado, 
 hacer validaciones, moverse etc). Y el método ``actualizar_habilidades``
 es el encargado de *dar vida* a las habilidades.

--- a/doc/source/comportamientos.rst
+++ b/doc/source/comportamientos.rst
@@ -7,7 +7,7 @@ una rutina o tarea para que la realicen.
 
 En pilas usamos el concepto de comportamiento. Un
 comportamiento es un objeto que le dice a
-un actor que debe hacer en todo momento.
+un actor qué debe hacer en todo momento.
 
 La utilidad de usar componentes es que puedes
 asociarlos y intercambiarlos libremente para
@@ -51,7 +51,7 @@ sola vez:
     pilas.ejecutar()
 
 De hecho, tenemos una variante que puede ser un poco
-mas interesante, decirle al mono que repita estas tareas todo
+mas interesante; decirle al mono que repita estas tareas todo
 el tiempo:
 
 .. code-block:: python

--- a/doc/source/controlando_la_pantalla.rst
+++ b/doc/source/controlando_la_pantalla.rst
@@ -64,7 +64,7 @@ Todos los actores tienen atributos cómo:
 
 que sirven para cambiar la posición del actor dentro de la escena.
 
-También encontrarás atributos que permite hacer lo mismo pero
+También encontrarás atributos que permiten hacer lo mismo, pero
 tomando como referencia alguno de los bordes del
 actor. Por ejemplo:
 

--- a/doc/source/controles.rst
+++ b/doc/source/controles.rst
@@ -2,7 +2,7 @@ Controles
 =========
 
 Si quieres conocer el estado de los controles
-en pilas tienes que usar el objeto ``pilas.mundo.control``.
+en pilas, tienes que usar el objeto ``pilas.mundo.control``.
 
 Por ejemplo, para hacer que un actor
 se mueva por la pantalla simplemente puedes crear
@@ -17,7 +17,7 @@ al actor y escribir estas sentencias.
 
 Esta no es la única forma de mover a un personaje por
 la pantalla, pero suele ser la mas conveniente porque
-es muy directa, y se pueda escribir en cualquier parte
+es muy directa, y se puede escribir en cualquier parte
 del código.
 
 Investigando al objeto control
@@ -48,8 +48,7 @@ es en la actualización de un actor.
 
 Esto se logra colocando un método llamado ``actualizar`` dentro
 del actor y haciendo la consulta ahí. Veamos un
-actor sencillo que se pueda mover de izquierda a derecha, pero
-que no salga nunca de la pantalla. El código sería
+actor sencillo que se pueda mover de izquierda a derecha. El código sería
 así:
 
 .. code-block:: python

--- a/doc/source/depurando.rst
+++ b/doc/source/depurando.rst
@@ -53,7 +53,7 @@ Activando los modos para detectar errores
 -----------------------------------------
 
 Ten en cuenta que puedes activar los modos depuración en cualquier momento,
-incluso en medio de una pasuair del modo depuración al
+incluso en medio de una pausa, ir del modo depuración al
 modo pausa y al revés. Los dos modos se pueden
 combinar fácilmente.
 

--- a/doc/source/dibujado_avanzado_con_superficies.rst
+++ b/doc/source/dibujado_avanzado_con_superficies.rst
@@ -8,7 +8,7 @@ de pizarra.
 
 Pero hay situaciones donde realmente necesitamos
 algo mas. En muchas ocasiones necesitamos que
-los actores se puedan tener una apariencia que
+los actores puedan tener una apariencia que
 construimos programáticamente (si existe la palabra...).
 
 Por ejemplo, imagina que queremos hacer un indicador

--- a/doc/source/dibujado_simple_en_pantalla.rst
+++ b/doc/source/dibujado_simple_en_pantalla.rst
@@ -101,7 +101,7 @@ Usando una Pizarra
 
 Si quieres dibujar sobre la pantalla pero
 de forma inmediata y con algunas posibilidades mas
-elaboradas puedes
+elaboradas, puedes
 usar un actor llamado ``Pizarra``. Esta no es la
 forma mas avanzada, pero es el siguiente paso después
 de dominar al actor ``Tortuga``.
@@ -109,7 +109,7 @@ de dominar al actor ``Tortuga``.
 Este actor ``Pizarra`` es cómo un lienzo invisible sobre
 el que podemos pintar imágenes, figuras
 geométricas y trazos de cualquier tipo. De hecho, el actor
-``Tortuga`` que vimos antes en realizada estaba
+``Tortuga`` que vimos antes, en realidad estaba
 dibujando sobre una pizarra, solo que lo hacía con
 animaciones y algo lento.
 

--- a/doc/source/escenas.rst
+++ b/doc/source/escenas.rst
@@ -17,7 +17,7 @@ Cosas a tener en cuenta
 -----------------------
 
 Hay algunas cosas a tener en cuenta
-a la hora de manejar escenaas, porque
+a la hora de manejar escenas, porque
 simplifican mucho el trabajo posterior:
 
 - La escena actual siempre está señalada por el atributo ``pilas.escena_actual()``.
@@ -38,7 +38,7 @@ escena limpia.
 Cambiando el fondo de las escenas
 ---------------------------------
 
-Para hacer un pequeña prueba sobre una
+Para hacer una pequeña prueba sobre una
 escena, podrías ejecutar la siguiente sentencia
 de código:
 

--- a/doc/source/eventos.rst
+++ b/doc/source/eventos.rst
@@ -37,7 +37,7 @@ Los ``eventos`` no disparan ninguna acción automática, nosotros
 los programadores somos los que tenemos que elegir los
 eventos importantes y elegir que hacer al respecto.
 
-Para utilidad a estas señales tenemos que vincularlas a funciones, de
+Para utilizar estas señales, tenemos que vincularlas a funciones, de
 forma que al emitirse la señal podamos ejecutar código.
 
 La función ``conectar``
@@ -129,7 +129,7 @@ De todas formas, puede que quieras conectar una señal, y por
 algún motivo desconectarla. Por ejemplo si el juego cambia
 de estado o algo así...
 
-Si ese es tú caso, simplemente asignarle un identificador único
+Si ese es tu caso, simplemente asígnale un identificador único
 al manejador de la señal y luego usa la función ``desconectar_por_id`` indicando
 el identificador.
 
@@ -140,7 +140,7 @@ Por ejemplo, las siguientes sentencias muestran eso:
     pilas.eventos.mueve_mouse.conectar(imprimir_posicion, id='drag')
     pilas.eventos.mueve_mouse.desconectar_por_id('drag')
     
-En la primer sentencia conecté la señal del evento a una función y le di
+En la primera sentencia conecté la señal del evento a una función y le di
 un valor al argumento ``id``. Este valor será el identificador
 de ese enlace. Y en la siguiente linea se utilizó el identificador
 para desconectarla.

--- a/doc/source/fisica.rst
+++ b/doc/source/fisica.rst
@@ -10,7 +10,7 @@ El protagonista es Box2D
 ------------------------
 
 El motor de física seleccionado para pilas se llama Box2D, el mismo
-motor de física utilizando en el juego Angry Birds.
+motor de física utilizado en el juego Angry Birds.
 
 Así, Box2D y PyBox2D son las bibliotecas protagonistas
 de casi toda la funcionalidad que vas a ver en este módulo.
@@ -202,9 +202,9 @@ que escribir ``circulo_dinamico.y = 200`` para mover al actor...
 
 Otra cosa a considerar, es que en nuestro ejemplo no ajustamos
 muy bien el tamaño del ``circulo_dinamico`` con el de la
-bomba. Esto es un detalles poco relevante aquí, porque solo
-quiero explicar cómo se usar el motor, pero cuando hagas tus
-juegos recuerda usar el modo depuración de física para detectar
+bomba. Esto es un detalle poco relevante aquí, porque solo
+quiero explicar cómo se usa el motor, pero cuando hagas tus
+juegos, recuerda usar el modo depuración de física para detectar
 estos detalles y corregirlos, son muy importantes para que
 tus usuarios disfruten del juego. Recuerda que ellos no
 verán los círculos rojos... solo verán la apariencia

--- a/doc/source/grupos.rst
+++ b/doc/source/grupos.rst
@@ -2,7 +2,7 @@ Grupos
 ======
 
 Ahora que podemos manejar a los actores de manera individual. Vamos
-a ver organizarlos en grupos.
+a ver cómo organizarlos en grupos.
 
 Organizar a los actores en grupo es de utilidad, porque generalmente
 es una buena idea agrupar a los actores por características y

--- a/doc/source/habilidades.rst
+++ b/doc/source/habilidades.rst
@@ -88,7 +88,7 @@ mezclando habilidades.
 Otras habilidades para investigar
 ---------------------------------
 
-Pilas viene con varias habiliades incluidas, pero
+Pilas viene con varias habilidades incluidas, pero
 lamentablemente este manual no las menciona a todas. Así
 que te recomendamos abrir un intérprete de python
 y consultarle directamente a él que habilidades tienes

--- a/doc/source/imagen.rst
+++ b/doc/source/imagen.rst
@@ -28,7 +28,7 @@ en pantalla:
     imagen = pilas.imagenes.cargar("mi_personaje.png")
     actor = pilas.actores.Actor(imagen)
 
-otra opcione similar es crear al actor, y luego
+otra opción similar es crear al actor, y luego
 asignarle la imagen:
 
 .. code-block:: python
@@ -161,7 +161,7 @@ filas.
 
 Cuando usas una grilla con pilas y columnas, la función ``avanzar``
 que vimos antes va a recorriendo los cuadros de la misma
-manera en que se leer una historieta (de izquierda
+manera en que se lee una historieta (de izquierda
 a derecha y de arriba a abajo).
 
 Esta es la apariencia de la imágen que usamos antes y

--- a/doc/source/interpolacion.rst
+++ b/doc/source/interpolacion.rst
@@ -20,7 +20,7 @@ es asignarle todos los valores en forma de lista:
 
 .. code-block:: python
 
-    actor.x = range(10, 100)
+    actor.x = range(10, 100, 10)
 
 o lo que es lo mismo:
 
@@ -77,6 +77,7 @@ podemos hacer algo como:
 
 .. code-block:: python
 
+    actor.rotacion = 0
     actor.rotacion = pilas.interpolar(360, duracion=5)
 
 con lo que estaríamos diciendo al personaje que dé un

--- a/doc/source/migrar_al_gestor_de_escenas.rst
+++ b/doc/source/migrar_al_gestor_de_escenas.rst
@@ -51,7 +51,7 @@ Todas las escenas de tu juego deben heredar ahora de `pilas.escena.Base`.
 
     class MiEscena(pilas.escena.Base):
 
-Y el otro cambio que debes realizar en la escenas es que el metodo ``__init__(self)`` no debe
+Y el otro cambio que debes realizar en las escenas es que el método ``__init__(self)`` no debe
 contener nada más que la llamada al ``__init__`` de la escena Base
 
 .. code-block:: python

--- a/doc/source/pilas_en_pyqt.rst
+++ b/doc/source/pilas_en_pyqt.rst
@@ -21,7 +21,7 @@ Con esto en mente vamos a proponernos un proyecto:
 
     Desarrollaremos una aplicación PyQt que muestre algunos actores en pantalla
     y al hacerle click sobre alguno nos permita seleccionar una imagen desde
-    un archivo para reemplazar desde a la del actor.
+    un archivo para reemplazar a la del actor.
 
 La estructura de objetos que manejaremos sera la siguiente:
 

--- a/doc/source/sonidos.rst
+++ b/doc/source/sonidos.rst
@@ -21,7 +21,7 @@ sonidos que trae pilas.
 Reproducir
 ----------
 
-La función ``sound.cargar`` nos retorna un objeto de tipo
+La función ``sonidos.cargar`` nos retorna un objeto de tipo
 ``Sonido`` que tiene un método para reproducirse llamado
 ``reproducir()``.
 

--- a/doc/source/tareas.rst
+++ b/doc/source/tareas.rst
@@ -18,7 +18,7 @@ en un determinado momento.
 
 Al momento de crear la tarea tenemos que
 pensar "en qué momento se tiene que ejecutar
-la tarea", y dependiendo de lo que queramos
+la tarea", y dependiendo de lo que queramos,
 tenemos que escribir algo cómo:
 
 .. code-block:: python
@@ -35,7 +35,7 @@ Hay tres tipos de creaciones de tareas:
 
 las tareas condicionales se ejecutarán siempre y cuando
 la función que las representa retorna True. Si la función
-retorna False la tareas dejará de ejecutarse.
+retorna False la tarea dejará de ejecutarse.
 
 
 Eliminar tareas


### PR DESCRIPTION
He revisado la documentación y he solucionado algunos errores tipográficos y de redacción. (Revisa antes los cambios por si he confundido expresiones argentinas. Hay algunas que conozco, pero no todas y, lo he corregido desde Español/España.

Aparte, puedo encargarme de actualizar el manual con el asistente nuevo y el nuevo cargador de ejemplos. (No sé si actualizar directamente al de la versión 0.74 o, directamente actualizarlo al nuevo. También puedo actualizar todas las demás capturas que aún muestran la interfaz antigua. Y he notado que el apartado https://pilas.readthedocs.org/en/latest/comportamientos.html#un-ejemplo-ir-de-un-lado-a-otro no se corresponde con el código fuente (¿Abro una nueva Issue para esto?).

También estoy colaborando en pilasweb y, estoy revisando a fondo pilas para poder hacer el port. Se podría aprovechar la misma documentación, ya que en realidad lo único que cambiaría sería la API. Entonces, en los casos que python supera en funcionalidad a JavaScript (como poder multiplicar objetos, listas, etc), remarcar en la documentación que sólo se puede hacer en python. ¿Qué te parece?
