### PR TITLE
Fijar los fondos de desplazamiento infinitos

### DIFF
--- a/pilas/fondos.py
+++ b/pilas/fondos.py
@@ -150,6 +150,18 @@ class Desplazamiento(Fondo):
             for capa in self.capas_auxiliares:
                 capa.x -= dx * self.velocidades[capa]
 
+        # Resituar capa cuando se sale del todo de la ventana
+        ancho = pilas.mundo.motor.ventana.width()
+        if self.ciclico:
+            for capa in self.capas:
+                if capa.derecha < -ancho / 2:
+                    capa.izquierda = \
+                        self.capas_auxiliares[self.capas.index(capa)].derecha
+            for capa in self.capas_auxiliares:
+                if capa.derecha < -ancho / 2:
+                    capa.izquierda = \
+                        self.capas[self.capas_auxiliares.index(capa)].derecha
+
 class Plano(Fondo):
 
     def __init__(self, ciclico=True):


### PR DESCRIPTION
En los fondos de desplazamiento infinitos, con ciclico=True, se crea una copia (capa auxiliar) que se desplaza a continuación de la primera. Pero cuando salen de la ventana por la izquierda, ya no vuelven a aparecer (puede verse en el ejemplo incorporado de Pilas, alargando el desplazamiento de la cámara).
El cambio, mira si la capa original o la auxiliar salen por la izquierda y en ese caso se recoloca detrás de la última.
