### PR TITLE
Añadida propiedad escala para cambiar tamaño de los poligonos

### DIFF
--- a/pilas/fisica.py
+++ b/pilas/fisica.py
@@ -703,7 +703,7 @@ class Poligono(Figura):
     def get_scale(self):
         return self._escala
 
-    escala = property(get_scale, set_scale, doc="definri escala del poligono")
+    escala = property(get_scale, set_scale, doc="definir escala del poligono")
 
 class ConstanteDeMovimiento():
     """Representa una constante de movimiento para el mouse."""


### PR DESCRIPTION
Es posible crear un polígono de x vértices y definir una escala con respecto a su tamaño inicial.

ejemplo: 

triangulo = pilas.fisica.Poligono(10,10,[(100, 2), (-50, 0), (-100, 100.0)])
triangulo.escala = 2
triangulo.escala = [3]
