### PR TITLE
Tortuga: dibuja solo cuando el lapiz esta bajo

### DIFF
--- a/pilas/actores/tortuga.py
+++ b/pilas/actores/tortuga.py
@@ -66,7 +66,8 @@ class Tortuga(Actor):
     def actualizar(self):
         """Actualiza su estado interno."""
         if self.anterior_x != self.x or self.anterior_y != self.y:
-            self.dibujar_linea_desde_el_punto_anterior()
+            if self.lapiz_bajo:
+                self.dibujar_linea_desde_el_punto_anterior()
             self.anterior_x = self.x
             self.anterior_y = self.y
 


### PR DESCRIPTION
Signed-off-by: José Luis Di Biase josx@interorganic.com.ar

Recien probando nos dimos cuenta que no funcionaba correctamente cuando se le inicializaba la tortuga para que no dibuje. 
