### PR TITLE
Reestructurando código para añadir complementos o plugins

### DIFF
--- a/pilas/__init__.py
+++ b/pilas/__init__.py
@@ -75,16 +75,14 @@ def iniciar(ancho=640, alto=480, titulo='Pilas', usar_motor='qtgl',
     :permitir_depuracion: si se desea tener habilidatas las funciones de depuracion de las teclas F5 a F12
     :audio: selecciona el motor de sonido a utilizar, los valores permitidos son 'deshabilitado', 'pygame', 'phonon' o 'gst'.
     :centrado: Indica si se desea centrar la ventana de pilas.
-    :cargar_plugins: Indica una lista de nombres de plugins que se desean cargar ena lista de nombres de plugins que se
-                     desean cargar. Si se especifica 'todos', se cargan todos los plugins encontrados.
+    :cargar_plugins: Indica si se desean cargar(True) o noFalse) los plugins creados en ~/.pilas/plugins/
     """
 
     global mundo
 
     if cargar_plugins:
-        lista_de_plugins_por_cargar = cargar_plugins
-        plugins_cargados = plugins.cargar_plugins(lista_de_plugins_por_cargar)
-        plugins.aplicar_plugins_en_habilidades(plugins_cargados, habilidades)
+        global complementos
+        complementos = plugins.Complementos()
 
     if not esta_inicializada():
         configuracion = obtener_configuracion()

--- a/pilas/plugins.py
+++ b/pilas/plugins.py
@@ -4,61 +4,49 @@ import os
 import sys
 import inspect
 
+class Complementos:
+    def __init__(self):
+        lista_de_plugins = self.__cargar_plugins()
+        self.__aplicar_plugins(lista_de_plugins)
 
-def obtener_ruta_de_plugins():
-    """Returna el path a los plugins de Pila."""
-    return os.path.expanduser('~/.pilas/plugins')
-
-
-def lista_de_plugins_encontrados():
-    """Retorna una lista de plugins encontrados de Pilas."""
-    directorio_de_plugins = obtener_ruta_de_plugins()
-    lista_de_plugins = list()
-    for archivo in os.listdir(directorio_de_plugins):
-        if not archivo.endswith('.py'):
-            continue
-        nombre_del_plugin, _ = archivo.split('.py')
-        lista_de_plugins.append(nombre_del_plugin)
-    return lista_de_plugins
+    def __obtener_ruta_de_plugins(self):
+        """Returna el path a los plugins de Pila."""
+        return os.path.expanduser('~/.pilas/plugins')
 
 
-def cargar_plugins(lista_de_plugins_por_cargar):
-    """Importa la lista de plugins dado. Retorna una lista
-    de modulos de plugins importados."""
+    def __lista_de_plugins_encontrados(self):
+        """Retorna una lista de plugins encontrados de Pilas."""
+        directorio_de_plugins = self.__obtener_ruta_de_plugins()
+        lista_de_plugins = list()
+        for archivo in os.listdir(directorio_de_plugins):
+            if not archivo.endswith('.py'):
+                continue
+            nombre_del_plugin, _ = archivo.split('.py')
+            lista_de_plugins.append(nombre_del_plugin)
+        return lista_de_plugins
 
-    # agrego el directorio de plugin al sys.path
-    ruta_de_plugins = obtener_ruta_de_plugins()
-    if not ruta_de_plugins in sys.path:
-        sys.path.append(ruta_de_plugins)
 
-    lista_de_plugins_importados = list()
-    plugins_encontrados = lista_de_plugins_encontrados()
+    def __cargar_plugins(self):
+        """Importa la lista de plugins dado. Retorna una lista
+        de modulos de plugins importados."""
 
-    # lista 'flag' para importar todos los plugins
-    TODOS_LOS_PLUGINS = ['todos']
+        # agrego el directorio de plugin al sys.path
+        ruta_de_plugins = self.__obtener_ruta_de_plugins()
+        if not ruta_de_plugins in sys.path:
+            sys.path.append(ruta_de_plugins)
 
-    if lista_de_plugins_por_cargar == TODOS_LOS_PLUGINS:
+        plugins_encontrados = self.__lista_de_plugins_encontrados()
+        lista_de_plugins_importados = list()
+
         for plugin in plugins_encontrados:
             plugin_importado = __import__(plugin)
             lista_de_plugins_importados.append(plugin_importado)
-    else:
-        for plugin in lista_de_plugins_por_cargar:
-            if plugin not in plugins_encontrados:
-                raise Exception('Plugin %s no encontrado.' % plugin)
-            plugin_importado = __import__(plugin)
-            lista_de_plugins_importados.append(plugin_importado)
-    return lista_de_plugins_importados
+
+        return lista_de_plugins_importados
 
 
-def aplicar_plugins_en_habilidades(lista_de_plugins, habilidades):
-    """Aplica los modulos de plugins dados a las habilidades."""
-
-    for modulo_de_plugin in lista_de_plugins:
-        miembros_del_plugin = inspect.getmembers(modulo_de_plugin)
-        for miembro in miembros_del_plugin:
-            nombre_de_clase, clase = miembro
-            if not inspect.isclass(clase):
-                continue
-            setattr(habilidades, nombre_de_clase, clase)
-    return habilidades
-
+    def __aplicar_plugins(self, lista_de_plugins):
+        """Aplica los modulos de plugins dados a las habilidades."""
+        for modulo_de_plugin in lista_de_plugins:
+            for nombre_de_clase, clase in inspect.getmembers(modulo_de_plugin):
+                setattr(self, nombre_de_clase, clase)


### PR DESCRIPTION
Limpiando código inecesario que se utilizaba si elegiamos cargar sólo ciertos complementos. Ahora elegimos si cargar todos los complementos o no cargarlos.
Podemos acceder a todos los complementos cómo "pilas.complementos.NombreDelComplemento".
