### PR TITLE
Migracion de PerseguirAOtroActor al nuevo framework + inteligencia variable

### DIFF
--- a/pilasengine/configuracion/__init__.py
+++ b/pilasengine/configuracion/__init__.py
@@ -54,7 +54,7 @@ class Configuracion(object):
                 'fuente': fuente + ' 15',
                 'audio_habilitado': False,
                 'pad_habilitado': False,
-                'aceleracion_habilitada': True,
+                'aceleracion_habilitada': False,
                 'autocompletado': True,
                 'version': VERSION, # Versión del formato de configuración.
                 }

--- a/pilasengine/configuracion/__init__.py
+++ b/pilasengine/configuracion/__init__.py
@@ -54,7 +54,7 @@ class Configuracion(object):
                 'fuente': fuente + ' 15',
                 'audio_habilitado': False,
                 'pad_habilitado': False,
-                'aceleracion_habilitada': False,
+                'aceleracion_habilitada': True,
                 'autocompletado': True,
                 'version': VERSION, # Versión del formato de configuración.
                 }

--- a/pilasengine/habilidades/__init__.py
+++ b/pilasengine/habilidades/__init__.py
@@ -98,6 +98,10 @@ class Habilidades(object):
         return self._referencia_habilidad('seguir_al_mouse', 'SeguirAlMouse')
 
     @property
+    def SeguirAOtroActor(self):
+        return self._referencia_habilidad('seguir_a_otro_actor', 'SeguirAOtroActor')
+
+    @property
     def PuedeExplotar(self):
         return self._referencia_habilidad('puede_explotar', 'PuedeExplotar')
 

--- a/pilasengine/habilidades/seguir_a_otro_actor.py
+++ b/pilasengine/habilidades/seguir_a_otro_actor.py
@@ -1,0 +1,45 @@
+# -*- encoding: utf-8 -*-
+# pilas engine: un motor para hacer videojuegos
+#
+# Copyright 2010-2014 - Hugo Ruscitti
+# License: LGPLv3 (see http://www.gnu.org/licenses/lgpl.html)
+#
+# Website - http://www.pilas-engine.com.ar
+from pilasengine import habilidades
+
+import random
+
+class SeguirAOtroActor(habilidades.Habilidad):
+    "Hace que un actor siga a otro actor."
+
+    def iniciar(self, receptor, actor_a_seguir, velocidad=5, inteligencia=1):
+        super(SeguirAOtroActor, self).iniciar(receptor)
+        self.objetivo = actor_a_seguir
+        self.velocidad = velocidad
+        self.inteligencia = 1
+        self.perdido = None
+
+    def actualizar(self):
+
+        def limitar(valor):
+            return min(max(valor, -self.velocidad), self.velocidad)
+
+        objetivo_x = self.objetivo.x
+        objetivo_y = self.objetivo.y
+
+        if self.inteligencia == 0:
+
+            if self.perdido:
+                # perdido, continua persiguiendo una posicion antigua
+                ( objetivo_x, objetivo_y ) = self.perdido
+                 
+                if random.randint(0, 10) > 7:
+                    # no se pierde mas
+                    self.perdido = None
+                    
+            elif random.randint(0, 10) > 7:
+                # se pierde
+                self.perdido = ( self.objetivo.x, self.objetivo.y )
+
+        self.receptor.x += limitar(objetivo_x - self.receptor.x)
+        self.receptor.y += limitar(objetivo_y - self.receptor.y)

--- a/pilasengine/tests/test_habilidades.py
+++ b/pilasengine/tests/test_habilidades.py
@@ -119,6 +119,96 @@ class TestHabilidades(unittest.TestCase):
         actor.aprender('disparar', municion="Mono")
         actor.aprender('disparar', municion="Caja")
 
+    def testPuedenSeguirAOtrosActoresCorrectament(self):
+        # se asegura que persigue bien en las cuatro direcciones
+        mono = self.pilas.actores.Mono()
+        mono.x = 100
+        mono.y = 100
+        bomba = self.pilas.actores.Bomba()
+        bomba.aprender(self.pilas.habilidades.SeguirAOtroActor, mono)
+
+        bomba._habilidades[1].actualizar()
+        assert bomba.x > 0
+        assert bomba.y > 0
+
+        bomba.x = 0
+        bomba.y = 0
+        mono.x = 100
+        mono.y = -100
+
+        bomba._habilidades[1].actualizar()
+        assert bomba.x > 0
+        assert bomba.y < 0
+
+        bomba.x = 0
+        bomba.y = 0
+        mono.x = -100
+        mono.y = 100
+
+        bomba._habilidades[1].actualizar()
+        assert bomba.x < 0
+        assert bomba.y > 0
+
+        bomba.x = 0
+        bomba.y = 0
+        mono.x = -100
+        mono.y = -100
+
+        bomba._habilidades[1].actualizar()
+        assert bomba.x < 0
+        assert bomba.y < 0
+
+        # se asegura que la velocidad funciona como tiene que funcionar
+
+        mono.x = 100
+        mono.y = 100
+        bomba.x = 0
+        bomba.y = 0
+
+        bomba._habilidades[1].velocidad = 1
+        bomba._habilidades[1].actualizar()
+        assert bomba.x == 1
+        assert bomba.y == 1
+
+        bomba.x = 0
+        bomba.y = 0
+
+        bomba._habilidades[1].velocidad = 5
+        bomba._habilidades[1].actualizar()
+        assert bomba.x == 5
+        assert bomba.y == 5
+
+        # se asegura que cuando es menos inteligente tarda mas en atrapar
+
+        mono.x = 100
+        mono.y = 100
+        bomba.x = 0
+        bomba.y = 0
+
+        bomba._habilidades[1].velocidad = 2
+
+        contador_inteligente = 0
+        while not (bomba.x == mono.x and bomba.y == mono.y):
+            mono.x += 1
+            bomba._habilidades[1].actualizar()
+            contador_inteligente += 1
+
+        mono.x = 100
+        mono.y = 100
+        bomba.x = 0
+        bomba.y = 0
+
+        bomba._habilidades[1].velocidad = 2
+        bomba._habilidades[1].inteligencia = 0
+
+        contador_perdido = 0
+        while not (bomba.x == mono.x and bomba.y == mono.y):
+            mono.x += 1
+            bomba._habilidades[1].actualizar()
+            contador_perdido += 1
+
+        assert contador_inteligente < contador_perdido
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
En linea con los nuevos nombres, la habilidad ahora se llama "seguir_a_otro_actor".

Con inteligencia=0 a veces se pierde y sigue una posicion anterior.

Para jugar un poco:

» import pilasengine
» pilas = pilasengine.iniciar()
» mono = pilas.actores.Mono()
» mono.aprender(pilas.habilidades.Arrastrable)
» bomba = pilas.actores.Bomba()
» bomba.aprender(pilas.habilidades.SeguirAOtroActor,mono,5)
» bomba.aprender(pilas.habilidades.SeguirAOtroActor,mono,5,0)
» bomba.aprender(pilas.habilidades.SeguirAOtroActor,mono,1,0)

Incluye casos de tests del viejo framework + caso para inteligencia = 0