### PR TITLE
Corrección del mensaje de activación forzada del audio.

### DIFF
--- a/pilasengine/__init__.py
+++ b/pilasengine/__init__.py
@@ -152,7 +152,7 @@ class Pilas(object):
 
     def forzar_habilitacion_de_audio(self):
         if self._audio_inicializado:
-            print("Error, el audio ya ha sido inicializado")
+            print("El audio ya ha sido inicializado")
         else:
             self._inicializar_audio()
             self.configuracion.definir_audio_habilitado(True)


### PR DESCRIPTION
Elimino la palabra error que da una sensación de que algo no anda bien, cuando en realidad está todo ok porque se intentó activar el audio y el mismo ya estaba activado.