### PR TITLE
Reubicacion llamada a super constr. texto (Fixes #295)

### DIFF
--- a/pilasengine/actores/texto.py
+++ b/pilasengine/actores/texto.py
@@ -27,11 +27,11 @@ class Texto(Actor):
                       se mostrara en varias lineas si no cabe en este límite.
         """
         self._ancho = ancho
-        Actor.__init__(self, pilas)
         self.__magnitud = magnitud
         self.__vertical = vertical
         self.__fuente = fuente
         self.__color = blanco
+        Actor.__init__(self, pilas)
         self.x = x
         self.y = y
         self.centro = ("centro", "centro")

--- a/pilasengine/tests/test_actores.py
+++ b/pilasengine/tests/test_actores.py
@@ -7,6 +7,10 @@ from PyQt4 import QtGui
 
 import pilasengine
 
+class SubTexto(pilasengine.actores.Texto):
+    def iniciar(self):
+        self.texto = "hola"
+
 
 class TestActores(unittest.TestCase):
     app = QtGui.QApplication(sys.argv)
@@ -20,6 +24,11 @@ class TestActores(unittest.TestCase):
 
         actor = self.pilas.actores.Texto()
         self.assertTrue(actor, "Puede crear un actor texto.")
+        self.assertTrue(actor.texto, "Sin texto")
+
+        actor = SubTexto(self.pilas)
+        self.assertTrue(actor, "Puede crear un actor sub-texto.")
+        self.assertTrue(actor.texto, "hola")
 
     def testFuncionanInterpolacionesSimples(self):
         actor = self.pilas.actores.Aceituna()


### PR DESCRIPTION
Siguiendo con lo comentado en el bug report, este cambio
parece arreglar el problema.

Moverlo mas abajo genera errores (al asignar las propiedades
falla ya que no estan todavia definidas).

Sin embargo, me intriga porque funciona:

La asignacion de self.texto es ejecutada despues de iniciar,
a mi entender el texto tendria que seguir siendo "Sin titulo".

Incluye caso de test.