### PR TITLE
[WIP] Workwaround para tener aceleración gráfica en placas nvidia con drivers privativos en GNU/Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 before_install:
   - "export DISPLAY=:99.0"
   - sudo apt-get update -qq
-  - sudo apt-get install -y python-setuptools python-qt4 python-qt4-gl git-core python-qt4-phonon build-essential python-dev subversion python-pygame swig
+  - sudo apt-get install -y python-setuptools python-qt4 python-qt4-gl git-core python-qt4-phonon python-opengl build-essential python-dev subversion python-pygame swig
   # Install SWIG >= 3 for box2d-py (See #83).
   - echo deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse | sudo tee /etc/apt/sources.list.d/box2d-py-swig.list
   - sudo apt-get -y install -t trusty-backports swig3.0

--- a/pilasengine/widget.py
+++ b/pilasengine/widget.py
@@ -41,6 +41,9 @@ class WidgetConAceleracion(QGLWidget):
     """
 
     def __init__(self, pilas, titulo, ancho, alto, capturar_errores=True):
+        # Workaround para este bug
+        # https://riverbankcomputing.com/pipermail/pyqt/2014-January/033681.html
+        from OpenGL import GL
         self.pilas = pilas
         super(WidgetConAceleracion, self).__init__()
         self.setMinimumSize(200, 200)


### PR DESCRIPTION
En mi computadora pilas falla al querer usar aceleración con el críptico error:

```
QGLShader: could not create shader
Vertex shader for simpleShaderProg (MainVertexShader & PositionOnlyVertexShader) failed to compile
QGLShader: could not create shader
Fragment shader for simpleShaderProg (MainFragmentShader & ShockingPinkSrcFragmentShader) failed to compile
QGLShaderProgram: could not create shader program
Errors linking simple shader: ""
QGLShader: could not create shader
Vertex shader for blitShaderProg (MainWithTexCoordsVertexShader & UntransformedPositionVertexShader) failed to compile
QGLShader: could not create shader
Fragment shader for blitShaderProg (MainFragmentShader & ImageSrcFragmentShader) failed to compile
QGLShaderProgram: could not create shader program
Errors linking blit shader: ""
QGLShader: could not create shader
Warning: "" failed to compile!
...
```

Investigando un poco encontré [este](https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826/comments/16) workaround, pero es posible que parte de la culpa de que no funcione correctamente sea mía (no recuerdo si tengo symlinkeado libGL a la librería de nVidia correspondiente).

Si alguien tiene chances de testear éste y [otros workarounds alternativos](https://bugs.launchpad.net/ubuntu/+source/python-qt4/+bug/941826/comments/20) (o de suministrar documentación para tener en cuenta este bug en caso de que aparezca) será bienvenido.

Este workaround requiere python-opengl, otros que encontré en internet requieren ctypes, hasta dónde entiendo este bug sólo afecta tarjetas gráficas nVidia, debian tiene varias opciones para configurar la instalación de los drivers y no testié todas como para ver si existen cosas mejores que parchear pilas.